### PR TITLE
fix(scheduler): adjust validation for full day logic

### DIFF
--- a/docs/resources/scheduler.md
+++ b/docs/resources/scheduler.md
@@ -41,7 +41,7 @@ resource "dotcommonitor_device" "example" {
 ### weekly_intervals
 * `days` - **(Required, list{string})** The days the scheduler is active. Can be a list of any of "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa".
 * `from` - **(Optional, string)** The time of day when the scheduler becomes active. Must be in the format of `##h##m`. The input gets convered to minutes before being passed to the API. Defaults to "0h0m" (start of day).
-* `to` - **(Optional, string)** The time of day when the scheduler turns inactive. Must be in the format of `##h##m`. The input gets convered to minutes before being passed to the API. Defaults to "24h0m" (end of day).
+* `to` - **(Optional, string)** The time of day when the scheduler turns inactive. Must be in the format of `##h##m`. The input gets convered to minutes before being passed to the API. Defaults to "23h59m" (end of day).
 * `enabled` - **(Optional, bool)** Indicates if the scheduler is enabled.
 
 ### excluded_time_intervals

--- a/dotcommonitor/resource_scheduler.go
+++ b/dotcommonitor/resource_scheduler.go
@@ -48,16 +48,16 @@ func resourceScheduler() *schema.Resource {
 							Optional: true,
 							Default:  "0h0m",
 							ValidateFunc: validation.All(
-								validation.StringMatch(regexp.MustCompile("^([0-9]|[1][0-9]|[2][0-4])h([0-5]?[0-9])m$"), "must be in the format of [0-23]h[0-59]m"),
+								validation.StringMatch(regexp.MustCompile("^([0-9]|[1][0-9]|[2][0-3])h([0-5]?[0-9])m$"), "must be in the format of [0-23]h[0-59]m"),
 								validateWeeklyIntervalFrom(),
 							),
 						},
 						"to": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "24h0m", // end of day
+							Default:  "23h59m", // end of day
 							ValidateFunc: validation.All(
-								validation.StringMatch(regexp.MustCompile("^([0-9]|[1][0-9]|[2][0-4])h([0-5]?[0-9])m$"), "must be in the format of [0-24]h[0-59]m"),
+								validation.StringMatch(regexp.MustCompile("^([0-9]|[1][0-9]|[2][0-3])h([0-5]?[0-9])m$"), "must be in the format of [0-23]h[0-59]m"),
 								validateWeeklyIntervalTo(),
 							),
 						},

--- a/dotcommonitor/validators.go
+++ b/dotcommonitor/validators.go
@@ -90,10 +90,10 @@ func validateWeeklyIntervalFrom() schema.SchemaValidateFunc {
 		if d, err := time.ParseDuration(v); err != nil {
 			es = append(es, fmt.Errorf("%s: unable to parse \"%v\" as duration, must be in the format of #h#m", k, v))
 		} else {
-			// then verify minutes are between 0 & 1439
+			// then verify minutes are between 0 & 1438
 			mins := int(d.Minutes())
-			if mins < 0 || mins > 1439 {
-				es = append(es, fmt.Errorf("%s: \"%v\", converted to \"%v\" minutes, is invalid - from time must be between 0 & 1439 minutes", k, v, mins))
+			if mins < 0 || mins > 1438 {
+				es = append(es, fmt.Errorf("%s: \"%v\", converted to \"%v\" minutes, is invalid - from time must be between 0 & 1438 minutes", k, v, mins))
 			}
 		}
 
@@ -117,10 +117,10 @@ func validateWeeklyIntervalTo() schema.SchemaValidateFunc {
 		if d, err := time.ParseDuration(v); err != nil {
 			es = append(es, fmt.Errorf("%s: unable to parse \"%v\" as duration, must be in the format of #h#m", k, v))
 		} else {
-			// then verify minutes are between 1 & 1440
+			// then verify minutes are between 1 & 1439
 			mins := int(d.Minutes())
-			if mins < 0 || mins > 1440 {
-				es = append(es, fmt.Errorf("%s: \"%v\", converted to \"%v\" minutes, is invalid - to time must be between 1 & 1440 minutes", k, v, mins))
+			if mins < 1 || mins > 1439 {
+				es = append(es, fmt.Errorf("%s: \"%v\", converted to \"%v\" minutes, is invalid - to time must be between 1 & 1439 minutes", k, v, mins))
 			}
 		}
 		return


### PR DESCRIPTION
Per Dotcom-Monitor support, a full day is represented
by From_Min=0, To_Min=1439. This corresponds to
0:00 AM - 11:59 PM in UI.

Closes #73